### PR TITLE
chore: create description for composer run command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,16 @@
         }
     },
     "scripts": {
-        "phpcbf": "vendor/bin/phpcbf",
-        "phpcs": "vendor/bin/phpcs",
-        "phpunit": "vendor/bin/phpunit",
+        "fix": [
+            "phpcbf"
+        ],
         "test": [
-            "@phpcs",
-            "@phpunit"
+            "phpcs",
+            "phpunit"
         ]
+    },
+    "scripts-descriptions": {
+        "fix": "Fix some detected issues",
+        "test": "Run all tests"
     }
 }


### PR DESCRIPTION
Some commands used in multiple projects can be abstracted on composer run workflow.

The intent behind it is to reduce the cognitive load for developers.

The commands will be listed on `composer list` and can be executed interactively with `composer run`.