### PR TITLE
ci: keep the testing pipeline simple

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2']
-        dependencies: ['normal', 'authoritative']
 
     steps:
     - uses: actions/checkout@v3
@@ -21,23 +20,10 @@ jobs:
         php-version: ${{ matrix.php-versions }}
 
     - name: Install dependencies
-      if: matrix.dependencies == 'normal'
-      run: composer install --prefer-dist
-      env:
-        COMPOSER_ROOT_VERSION: dev-master
+      run: composer install
 
-    - name: Install dependencies
-      if: matrix.dependencies == 'authoritative'
-      run: composer install --prefer-dist --classmap-authoritative
-      env:
-        COMPOSER_ROOT_VERSION: dev-master
-    - name: Run Phpunit
-      run: composer run phpunit
-
-    - name: Run PhpCs
-      if: matrix.php-versions == '8.2' && matrix.dependencies == 'normal'
-      run: composer run phpcs
+    - name: Run tests
+      run: composer run test
 
     - name: Run Qodana
-      if: matrix.php-versions == '8.2' && matrix.dependencies == 'normal'
       uses: JetBrains/qodana-action@v2023.1.5


### PR DESCRIPTION
We can keep some project with a simple pipeline using the same commands from
`composer run` used in development.

In this case we support just PHP 8.2 but for multiple versions does make sense
to run one pipeline per version.
